### PR TITLE
Shorter notams

### DIFF
--- a/src/components/notam/NotamClientComponent.js
+++ b/src/components/notam/NotamClientComponent.js
@@ -103,7 +103,22 @@ export default function NotamClientComponent() {
                         right: 15,
                     }}
                 >
-                    NOTAM Data from: lentopaikat.fi, CC BY 4.0
+                    {'NOTAM  Data from: '}
+                    <a
+                        style={{
+                            color: '#006699',
+                        }}
+                        href="https://lentopaikat.fi/notam/notam.php?a=EFPR"
+                    >
+                        lentopaikat.fi
+                    </a>
+                    {', '}
+                    <a
+                        style={{ color: '#006699' }}
+                        href="https://creativecommons.org/licenses/by/4.0/"
+                    >
+                        CC BY 4.0
+                    </a>
                 </p>
             </div>
         </div>

--- a/src/components/notam/NotamClientComponent.js
+++ b/src/components/notam/NotamClientComponent.js
@@ -78,10 +78,34 @@ export default function NotamClientComponent() {
     }
 
     return (
-        <div style={{ fontSize: '0.75rem' }}>
-            <pre>{notam.title}</pre>
+        <div
+            style={{
+                overflow: 'auto',
+                height: '315px',
+                fontSize: '0.9rem',
+                position: 'relative',
+            }}
+        >
             <pre>{notam.content}</pre>
-            <p>Last updated: {timeSinceLastUpdate}</p>
+            <div style={{ fontSize: '0.6rem', top: 615 }}>
+                <p
+                    style={{
+                        position: 'fixed',
+                        top: 615,
+                    }}
+                >
+                    Last updated: {timeSinceLastUpdate}
+                </p>
+                <p
+                    style={{
+                        position: 'fixed',
+                        top: 615,
+                        right: 15,
+                    }}
+                >
+                    NOTAM Data from: lentopaikat.fi, CC BY 4.0
+                </p>
+            </div>
         </div>
     );
 }

--- a/src/pages/api/notams.js
+++ b/src/pages/api/notams.js
@@ -18,14 +18,6 @@ export default async function GET(req, res) {
         );
 
         if (!response.ok) {
-            /*return new Response(
-                JSON.stringify({ message: 'Failed to fetch NOTAM data' }),
-                {
-                    status: 500,
-                    headers: { 'Content-Type': 'application/json' },
-                }
-            );
-            */
             res.status(500).json({ message: 'Failed to fetch NOTAM data' });
         }
 
@@ -36,16 +28,14 @@ export default async function GET(req, res) {
             .text()
             .trim()
             .replaceAll('?', '')
-            .replaceAll('�', ' ');
+            .replaceAll('�', ' ')
+            .replace('\n\n+\n', '\n\n')
+            .replace('EFPR - REDSTONE AERO\n\n', '')
+            .replace('\n', '')
+            .replaceAll('\n\n', '\n');
         cachedData = { title, content };
         lastFetchTime = Date.now();
     }
 
-    /*return new Response(JSON.stringify({ data: cachedData }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-    });*/
-    res.status(200)
-        //.setHeaders({ 'Content-Type': 'application/json' })
-        .json({ data: cachedData });
+    res.status(200).json({ data: cachedData });
 }


### PR DESCRIPTION
Reduced the text shown in the notams div.
Added the source reference for notams, as well as moved the notams' last update message to the bottom left of the notams div. 
Since I assumed the tv will be 1920x1080 please use that resolution when checking the page otherwise those two info will not be aligned correctly.
The div now overflows correctly in case the text is too long.